### PR TITLE
set Stash next_free to 0 when len becomes 0

### DIFF
--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -360,6 +360,9 @@ impl<V> Stash<V> {
                 Entry::Full(value) => {
                     self.next_free = index;
                     self.size -= 1;
+                    if self.size == 0 {
+                      self.next_free = 0;
+                    }
                     return Some(value);
                 }
             }
@@ -399,6 +402,7 @@ impl<V> Stash<V> {
             self.next_free = i;
             self.size -= 1;
         }
+        self.next_free = 0;
     }
 }
 


### PR DESCRIPTION
So that a newly allocated stash behaves the same as a recently
cleared stash (either using clear or the last element has been
removed with take).
