### PR TITLE
Reset Stash next_free to 0 and clear data when size becomes 0

### DIFF
--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -386,7 +386,8 @@ impl<V> Stash<V> {
         }
     }
 
-    /// Clear the stash
+    /// Clear the stash. Cleared stash will give the same keys as a
+    /// new stash for subsequent puts.
     pub fn clear(&mut self) {
         // Do it this way so that nothing bad happens if a destructor panics.
         for (i, entry) in self.data.iter_mut().enumerate() {

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -360,6 +360,9 @@ impl<V> Stash<V> {
                 Entry::Full(value) => {
                     self.next_free = index;
                     self.size -= 1;
+                    if self.size == 0 {
+                      self.next_free = 0;
+                    }
                     return Some(value);
                 }
             }
@@ -399,6 +402,7 @@ impl<V> Stash<V> {
             self.next_free = i;
             self.size -= 1;
         }
+        self.next_free = 0;
     }
 }
 

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -351,7 +351,6 @@ impl<V> Stash<V> {
 
     /// Take an item from a slot (if non empty).
     pub fn take(&mut self, index: usize) -> Option<V> {
-        let mut out = None;
         if let Some(entry) = self.data.get_mut(index) {
             match mem::replace(entry, Entry::Empty(self.next_free)) {
                 Entry::Empty(free_slot) => {
@@ -362,17 +361,11 @@ impl<V> Stash<V> {
                 Entry::Full(value) => {
                     self.next_free = index;
                     self.size -= 1;
-                    out = Some(value);
+                    return Some(value);
                 }
             }
         }
-        if let &Some(_) = &out {
-          if self.size == 0 {
-            self.data.clear();
-            self.next_free = 0;
-          }
-        }
-        out
+        None
     }
 
     /// Get a reference to the value at `index`.

--- a/tests/stash.rs
+++ b/tests/stash.rs
@@ -41,7 +41,7 @@ fn get() {
 }
 
 #[test]
-fn reset_zero() {
+fn clear_zero() {
     let mut stash1 = Stash::new();
     for _ in 0..3 {
       stash1.put (());
@@ -52,12 +52,8 @@ fn reset_zero() {
     for _ in 0..4 {
       assert_eq!(stash1.put (()), stash2.put (()));
     }
-    for i in 0..4 {
-      stash1.take (i);
-    }
-    for i in 0..4 {
-      stash2.take (3-i);
-    }
+    stash1.clear();
+    stash2.clear();
     assert_eq!(stash1.len(), 0);
     assert_eq!(stash2.len(), 0);
     let mut stash3 = Stash::new();

--- a/tests/stash.rs
+++ b/tests/stash.rs
@@ -40,3 +40,31 @@ fn get() {
     assert_eq!(stash[indices[2]], 1);
 }
 
+#[test]
+fn reset_zero() {
+    let mut stash1 = Stash::new();
+    for _ in 0..3 {
+      stash1.put (());
+    }
+    stash1.clear();
+    assert_eq!(stash1.len(), 0);
+    let mut stash2 = Stash::new();
+    for _ in 0..4 {
+      assert_eq!(stash1.put (()), stash2.put (()));
+    }
+    for i in 0..4 {
+      stash1.take (i);
+    }
+    for i in 0..4 {
+      stash2.take (3-i);
+    }
+    assert_eq!(stash1.len(), 0);
+    assert_eq!(stash2.len(), 0);
+    let mut stash3 = Stash::new();
+    for _ in 0..5 {
+      let i = stash3.put (());
+      assert_eq!(i, stash1.put(()));
+      assert_eq!(i, stash2.put(()));
+    }
+}
+


### PR DESCRIPTION
So that a newly allocated stash behaves the same as a recently
cleared stash (either using clear or the last element has been
removed with take).

Did a quick trial with a type that implements Drop to make sure nothing is being dropped twice, looked okay.
