### PR TITLE
Make stashes generic over index types

### DIFF
--- a/benches/stash.rs
+++ b/benches/stash.rs
@@ -9,7 +9,7 @@ use stash::Stash;
 
 #[bench]
 fn put_and_take(b: &mut Bencher) {
-    let mut stash = Stash::with_capacity(6);
+    let mut stash: Stash<&str, usize> = Stash::with_capacity(6);
     b.iter(|| {
         let t1 = stash.put("something");
         let t2 = stash.put("something");
@@ -28,7 +28,7 @@ fn put_and_take(b: &mut Bencher) {
 
 #[bench]
 fn put_and_take_unchecked(b: &mut Bencher) {
-    let mut stash = Stash::with_capacity(6);
+    let mut stash: Stash<&str, usize> = Stash::with_capacity(6);
     b.iter(|| {
         let t1 = stash.put("something");
         let t2 = stash.put("something");
@@ -47,7 +47,7 @@ fn put_and_take_unchecked(b: &mut Bencher) {
 
 #[bench]
 fn put_and_take_block(b: &mut Bencher) {
-    let mut stash = Stash::with_capacity(10);
+    let mut stash: Stash<&str, usize> = Stash::with_capacity(10);
     b.iter(|| {
         let t0 = stash.put("something");
         let t1 = stash.put("something");
@@ -94,7 +94,7 @@ fn put_and_take_block(b: &mut Bencher) {
 
 #[bench]
 fn put_and_take_unchecked_block(b: &mut Bencher) {
-    let mut stash = Stash::with_capacity(10);
+    let mut stash: Stash<&str, usize> = Stash::with_capacity(10);
     b.iter(|| {
         let t0 = stash.put("something");
         let t1 = stash.put("something");

--- a/benches/stash.rs
+++ b/benches/stash.rs
@@ -9,7 +9,7 @@ use stash::Stash;
 
 #[bench]
 fn put_and_take(b: &mut Bencher) {
-    let mut stash: Stash<&str, usize> = Stash::with_capacity(6);
+    let mut stash = Stash::with_capacity(6);
     b.iter(|| {
         let t1 = stash.put("something");
         let t2 = stash.put("something");
@@ -28,7 +28,7 @@ fn put_and_take(b: &mut Bencher) {
 
 #[bench]
 fn put_and_take_unchecked(b: &mut Bencher) {
-    let mut stash: Stash<&str, usize> = Stash::with_capacity(6);
+    let mut stash = Stash::with_capacity(6);
     b.iter(|| {
         let t1 = stash.put("something");
         let t2 = stash.put("something");
@@ -47,7 +47,7 @@ fn put_and_take_unchecked(b: &mut Bencher) {
 
 #[bench]
 fn put_and_take_block(b: &mut Bencher) {
-    let mut stash: Stash<&str, usize> = Stash::with_capacity(10);
+    let mut stash = Stash::with_capacity(10);
     b.iter(|| {
         let t0 = stash.put("something");
         let t1 = stash.put("something");
@@ -94,7 +94,7 @@ fn put_and_take_block(b: &mut Bencher) {
 
 #[bench]
 fn put_and_take_unchecked_block(b: &mut Bencher) {
-    let mut stash: Stash<&str, usize> = Stash::with_capacity(10);
+    let mut stash = Stash::with_capacity(10);
     b.iter(|| {
         let t0 = stash.put("something");
         let t1 = stash.put("something");

--- a/examples/custom_index.rs
+++ b/examples/custom_index.rs
@@ -1,0 +1,47 @@
+extern crate stash;
+
+use std::u16;
+
+use stash::Stash;
+
+
+#[derive(Clone,Copy,Debug,Eq,Ord,PartialEq,PartialOrd)]
+struct SmallIndex(u16);
+
+impl stash::Index for SmallIndex {
+    fn from_usize(idx: usize) -> Self {
+        if idx > u16::MAX as usize {
+            panic!("index type overflowing!");
+        }
+        SmallIndex(idx as u16)
+    }
+
+    fn into_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+fn main() {
+    let mut stash = Stash::default();
+
+    // the following type annotation makes the rust compiler understand what type of index
+    // we want to use. Only needed once.
+    let key1: SmallIndex = stash.put("foo");
+    let key2 = stash.put("bar");
+    let key3 = stash.put("baz");
+
+    assert_eq!(stash[key1], "foo");
+    assert_eq!(stash[key2], "bar");
+    assert_eq!(stash[key3], "baz");
+    assert_eq!(stash.len(), 3);
+
+    assert_eq!(stash.take(key2), Some("bar"));
+    assert_eq!(stash.len(), 2);
+
+    let key4 = stash.put("bin");
+    assert_eq!(stash.len(), 3);
+    assert_eq!(stash[key4], "bin");
+    let mut values: Vec<_> = stash.into_iter().map(|(_, v)| v).collect();
+    values.sort();
+    assert_eq!(values, vec!["baz", "bin", "foo"]);
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,22 @@
+/// Every index type to be used with Stash needs to implement this trait
+pub trait Index {
+    /// Create an index from `usize`.
+    ///
+    /// This method should panic if `idx` is out of acceptable range.
+    fn from_usize(idx: usize) -> Self;
+
+    /// Turn this index into `usize`
+    fn into_usize(self) -> usize;
+}
+
+// Auto implement this for types equivalent to `usize`.
+impl<T> Index for T
+    where T: From<usize> + Into<usize>
+{
+    fn from_usize(idx: usize) -> Self {
+        From::from(idx)
+    }
+    fn into_usize(self) -> usize {
+        Into::into(self)
+    }
+}

--- a/src/iter_macro.rs
+++ b/src/iter_macro.rs
@@ -2,10 +2,10 @@ macro_rules! impl_iter {
     (@item_identity, $i:item) => {
         $i
     };
-    ($name:ident, ($($tparm:tt)*), $item:ty, $fun:expr) => {
+    ($name:ident, ($($tparm:tt)*), $item:ty, $fun:expr, ($($wh_clause:tt)*)) => {
         impl_iter! {
             @item_identity,
-            impl $($tparm)* Iterator for $name $($tparm)* {
+            impl $($tparm)* Iterator for $name $($tparm)* $($wh_clause)* {
                 type Item = $item;
 
                 fn next(&mut self) -> Option<Self::Item> {
@@ -32,7 +32,7 @@ macro_rules! impl_iter {
 
         impl_iter! {
             @item_identity,
-            impl $($tparm)* ExactSizeIterator for $name $($tparm)* {
+            impl $($tparm)* ExactSizeIterator for $name $($tparm)* $($wh_clause)* {
                 fn len(&self) -> usize {
                     self.len
                 }
@@ -41,7 +41,7 @@ macro_rules! impl_iter {
 
         impl_iter! {
             @item_identity,
-            impl $($tparm)* DoubleEndedIterator for $name $($tparm)* {
+            impl $($tparm)* DoubleEndedIterator for $name $($tparm)* $($wh_clause)* {
                 fn next_back(&mut self) -> Option<Self::Item> {
                     let item = (&mut self.inner).rev().filter_map($fun).next();
                     if item.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,12 @@ extern crate unreachable;
 #[macro_use]
 mod iter_macro;
 
+pub mod index;
 pub mod stash;
 pub mod unique_stash;
 
+#[doc(inline)]
+pub use index::Index;
 #[doc(inline)]
 pub use stash::Stash;
 #[doc(inline)]

--- a/src/stash/entry.rs
+++ b/src/stash/entry.rs
@@ -1,3 +1,5 @@
+use index::Index;
+
 #[derive(Clone)]
 pub enum Entry<V> {
     Empty(usize /* next free index */),
@@ -30,23 +32,23 @@ pub fn value_mut<V>(entry: &mut Entry<V>) -> Option<&mut V> {
     }
 }
 
-pub fn value_index_ref<V>((i, entry): (usize, &Entry<V>)) -> Option<(usize, &V)> {
+pub fn value_index_ref<V, Ix: Index>((i, entry): (usize, &Entry<V>)) -> Option<(Ix, &V)> {
     match *entry {
-        Full(ref value) => Some((i, value)),
+        Full(ref value) => Some((Ix::from_usize(i), value)),
         Empty(_) => None,
     }
 }
 
-pub fn value_index_mut<V>((i, entry): (usize, &mut Entry<V>)) -> Option<(usize, &mut V)> {
+pub fn value_index_mut<V, Ix: Index>((i, entry): (usize, &mut Entry<V>)) -> Option<(Ix, &mut V)> {
     match *entry {
-        Full(ref mut value) => Some((i, value)),
+        Full(ref mut value) => Some((Ix::from_usize(i), value)),
         Empty(_) => None,
     }
 }
 
-pub fn value_index<V>((i, entry): (usize, Entry<V>)) -> Option<(usize, V)> {
+pub fn value_index<V, Ix: Index>((i, entry): (usize, Entry<V>)) -> Option<(Ix, V)> {
     match entry {
-        Full(value) => Some((i, value)),
+        Full(value) => Some((Ix::from_usize(i), value)),
         Empty(_) => None,
     }
 }

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -133,7 +133,7 @@ pub struct Stash<V, Ix = usize> {
 impl<V> Stash<V, usize> {
     /// Constructs a new, empty `Stash<V, usize>`.
     ///
-    /// This is a convenience method. Use `Stash::with_capacity` or `Stash::default` for
+    /// This is a convenience method. Use `Stash::default` for
     /// a constructor that is generic in the type of index used.
     ///
     /// The stash will not allocate until elements are put onto it.
@@ -149,12 +149,13 @@ impl<V> Stash<V, usize> {
     pub fn new() -> Self {
         Stash::with_capacity(0)
     }
-}
 
-impl<V, Ix> Stash<V, Ix>
-    where Ix: Index
-{
-    /// Constructs a new, empty `Stash<V, Ix>` with the specified capacity.
+    /// Constructs a new, empty `Stash<V, usize>` with the specified capacity.
+    ///
+    /// This is a convenience method. Use `Stash::default` for
+    /// a constructor that is generic in the type of index used. In that case
+    /// you can call `reserve` on the newly created stash to specify the
+    /// capacity you need.
     ///
     /// The stash will be able to hold exactly `capacity` elements without
     /// reallocating. If `capacity` is 0, the stash will not allocate.
@@ -169,7 +170,7 @@ impl<V, Ix> Stash<V, Ix>
     /// ```
     /// use stash::Stash;
     ///
-    /// let mut stash: Stash<i32, usize> = Stash::with_capacity(10);
+    /// let mut stash = Stash::with_capacity(10);
     ///
     /// // The stash contains no items, even though it has capacity for more
     /// assert_eq!(stash.len(), 0);
@@ -191,7 +192,11 @@ impl<V, Ix> Stash<V, Ix>
             _marker: marker::PhantomData,
         }
     }
+}
 
+impl<V, Ix> Stash<V, Ix>
+    where Ix: Index
+{
     /// Returns the number of elements the stash can hold without reallocating.
     ///
     /// # Examples
@@ -553,6 +558,11 @@ impl<'a, V, Ix: Index> ops::IndexMut<Ix> for Stash<V, Ix> {
 impl<V, Ix: Index> Default for Stash<V, Ix> {
     #[inline]
     fn default() -> Self {
-        Stash::with_capacity(0)
+        Stash {
+            data: Vec::new(),
+            next_free: 0,
+            size: 0,
+            _marker: marker::PhantomData,
+        }
     }
 }

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -1,22 +1,25 @@
 use std::fmt;
 use std::vec;
 use std::iter;
-use std::ops::{Index, IndexMut};
+use std::marker;
+use std::ops;
 use std::slice;
 use std::mem;
 
 mod entry;
 use self::entry::Entry;
+use index::Index;
 
-pub struct Extend<'a, I>
+pub struct Extend<'a, I, Ix>
     where I: Iterator,
-          I::Item: 'a
+          I::Item: 'a,
+          Ix: Index + 'a
 {
     iter: I,
-    stash: &'a mut Stash<I::Item>,
+    stash: &'a mut Stash<I::Item, Ix>,
 }
 
-impl<'a, I> Drop for Extend<'a, I>
+impl<'a, I, Ix: Index> Drop for Extend<'a, I, Ix>
     where I: Iterator,
           I::Item: 'a
 {
@@ -25,13 +28,13 @@ impl<'a, I> Drop for Extend<'a, I>
     }
 }
 
-impl<'a, I> Iterator for Extend<'a, I>
+impl<'a, I, Ix: Index> Iterator for Extend<'a, I, Ix>
     where I: Iterator,
           I::Item: 'a
 {
-    type Item = usize;
+    type Item = Ix;
 
-    fn next(&mut self) -> Option<usize> {
+    fn next(&mut self) -> Option<Ix> {
         self.iter.next().map(|v| self.stash.put(v))
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -39,37 +42,40 @@ impl<'a, I> Iterator for Extend<'a, I>
     }
 }
 
-impl<'a, I> ExactSizeIterator for Extend<'a, I>
+impl<'a, I, Ix: Index> ExactSizeIterator for Extend<'a, I, Ix>
     where I: ExactSizeIterator,
           I::Item: 'a
 {
 }
 
-impl<'a, I> DoubleEndedIterator for Extend<'a, I>
+impl<'a, I, Ix: Index> DoubleEndedIterator for Extend<'a, I, Ix>
     where I: DoubleEndedIterator,
           I::Item: 'a
 {
-    fn next_back(&mut self) -> Option<usize> {
+    fn next_back(&mut self) -> Option<Ix> {
         self.iter.next_back().map(|v| self.stash.put(v))
     }
 }
 
 /// Iterator over the `(index, &value)` pairs.
-pub struct Iter<'a, V: 'a> {
+pub struct Iter<'a, V: 'a, Ix: Index> {
     inner: iter::Enumerate<slice::Iter<'a, Entry<V>>>,
     len: usize,
+    _marker: marker::PhantomData<fn() -> Ix>,
 }
 
 /// Iterator over the `(index, &mut value)` pairs.
-pub struct IterMut<'a, V: 'a> {
+pub struct IterMut<'a, V: 'a, Ix: Index> {
     inner: iter::Enumerate<slice::IterMut<'a, Entry<V>>>,
     len: usize,
+    _marker: marker::PhantomData<fn() -> Ix>,
 }
 
 /// Iterator over the `(index, value)` pairs.
-pub struct IntoIter<V> {
+pub struct IntoIter<V, Ix: Index> {
     inner: iter::Enumerate<vec::IntoIter<Entry<V>>>,
     len: usize,
+    _marker: marker::PhantomData<fn() -> Ix>,
 }
 
 /// Iterator over references to the values in the stash.
@@ -90,14 +96,13 @@ pub struct IntoValues<V> {
     len: usize,
 }
 
-impl_iter!(Values, (<'a, V>), &'a V, entry::value_ref);
-impl_iter!(ValuesMut, (<'a, V>), &'a mut V, entry::value_mut);
-impl_iter!(IntoValues, (<V>), V, entry::value);
+impl_iter!(Values, (<'a, V>), &'a V, entry::value_ref, ());
+impl_iter!(ValuesMut, (<'a, V>), &'a mut V, entry::value_mut, ());
+impl_iter!(IntoValues, (<V>), V, entry::value, ());
 
-impl_iter!(Iter, (<'a, V>), (usize, &'a V), entry::value_index_ref);
-
-impl_iter!(IterMut, (<'a, V>), (usize, &'a mut V), entry::value_index_mut);
-impl_iter!(IntoIter, (<V>), (usize, V), entry::value_index);
+impl_iter!(Iter, (<'a, V, Ix>), (Ix, &'a V), entry::value_index_ref, (where Ix: Index));
+impl_iter!(IterMut, (<'a, V, Ix>), (Ix, &'a mut V), entry::value_index_mut, (where Ix: Index));
+impl_iter!(IntoIter, (<V, Ix>), (Ix, V), entry::value_index, (where Ix: Index));
 
 /// An `O(1)` amortized table that reuses keys.
 ///
@@ -116,14 +121,20 @@ impl_iter!(IntoIter, (<V>), (usize, V), entry::value_index);
 ///
 /// An example use case is a file descriptor table.
 #[derive(Clone)]
-pub struct Stash<V> {
+pub struct Stash<V, Ix = usize> {
     data: Vec<Entry<V>>,
     size: usize,
     next_free: usize,
+    // add a phantom user of the Ix type to make sure an instance of Stash is bound to one
+    // specific index type, separate calls to put and get can't use different index types.
+    _marker: marker::PhantomData<fn(Ix) -> Ix>,
 }
 
-impl<V> Stash<V> {
-    /// Constructs a new, empty `Stash<T>`.
+impl<V> Stash<V, usize> {
+    /// Constructs a new, empty `Stash<V, usize>`.
+    ///
+    /// This is a convenience method. Use `Stash::with_capacity` or `Stash::default` for
+    /// a constructor that is generic in the type of index used.
     ///
     /// The stash will not allocate until elements are put onto it.
     ///
@@ -138,8 +149,12 @@ impl<V> Stash<V> {
     pub fn new() -> Self {
         Stash::with_capacity(0)
     }
+}
 
-    /// Constructs a new, empty `Stash<T>` with the specified capacity.
+impl<V, Ix> Stash<V, Ix>
+    where Ix: Index
+{
+    /// Constructs a new, empty `Stash<V, Ix>` with the specified capacity.
     ///
     /// The stash will be able to hold exactly `capacity` elements without
     /// reallocating. If `capacity` is 0, the stash will not allocate.
@@ -154,7 +169,7 @@ impl<V> Stash<V> {
     /// ```
     /// use stash::Stash;
     ///
-    /// let mut stash: Stash<i32> = Stash::with_capacity(10);
+    /// let mut stash: Stash<i32, usize> = Stash::with_capacity(10);
     ///
     /// // The stash contains no items, even though it has capacity for more
     /// assert_eq!(stash.len(), 0);
@@ -173,6 +188,7 @@ impl<V> Stash<V> {
             data: Vec::with_capacity(capacity),
             next_free: 0,
             size: 0,
+            _marker: marker::PhantomData,
         }
     }
 
@@ -266,9 +282,13 @@ impl<V> Stash<V> {
     ///
     /// Returns the index at which this value was stored.
     ///
-    /// *Panics* if the size of the `Stash<V>` would overflow `usize::MAX`.
+    /// # Panics
+    ///
+    /// Panics if the size of the `Stash<V, Ix>` would overflow the `Ix` index type.
     #[inline]
-    pub fn put(&mut self, value: V) -> usize {
+    pub fn put(&mut self, value: V) -> Ix {
+        // create index first so the potential panic would happen before any modification
+        let idx = Ix::from_usize(self.next_free);
         let loc = self.next_free;
         debug_assert!(loc <= self.data.len());
 
@@ -285,7 +305,7 @@ impl<V> Stash<V> {
             }
         };
         self.size += 1;
-        loc
+        idx
     }
 
     /// Put all items in the iterator into the stash.
@@ -294,7 +314,7 @@ impl<V> Stash<V> {
     /// items are actually inserted as the Iterator is read. If the returned
     /// Iterator is dropped, the rest of the items will be inserted all at once.
     #[inline]
-    pub fn extend<I>(&mut self, iter: I) -> Extend<I>
+    pub fn extend<I>(&mut self, iter: I) -> Extend<I, Ix>
         where I: Iterator<Item = V>
     {
         let (lower, _) = iter.size_hint();
@@ -309,10 +329,11 @@ impl<V> Stash<V> {
     ///
     /// Returns an iterator that yields `(index, &value)` pairs.
     #[inline]
-    pub fn iter(&self) -> Iter<V> {
+    pub fn iter(&self) -> Iter<V, Ix> {
         Iter {
             len: self.len(),
             inner: self.data.iter().enumerate(),
+            _marker: marker::PhantomData,
         }
     }
 
@@ -320,10 +341,11 @@ impl<V> Stash<V> {
     ///
     /// Returns an iterator that yields `(index, &mut value)` pairs.
     #[inline]
-    pub fn iter_mut(&mut self) -> IterMut<V> {
+    pub fn iter_mut(&mut self) -> IterMut<V, Ix> {
         IterMut {
             len: self.len(),
             inner: self.data.iter_mut().enumerate(),
+            _marker: marker::PhantomData,
         }
     }
 
@@ -363,8 +385,9 @@ impl<V> Stash<V> {
     }
 
     /// Take an item from a slot (if non empty).
-    pub fn take(&mut self, index: usize) -> Option<V> {
-        match self.data.get_mut(index) {
+    pub fn take(&mut self, index: Ix) -> Option<V> {
+        let take_index = index.into_usize();
+        match self.data.get_mut(take_index) {
             None => None,
             Some(entry) => match mem::replace(entry, Entry::Empty(self.next_free)) {
                 Entry::Empty(free_slot) => {
@@ -372,7 +395,7 @@ impl<V> Stash<V> {
                     None
                 },
                 Entry::Full(value) => {
-                    self.next_free = index;
+                    self.next_free = take_index;
                     self.size -= 1;
                     Some(value)
                 }
@@ -387,11 +410,12 @@ impl<V> Stash<V> {
     /// `indices` from `put` and is sure not to have taken the value
     /// associated with the given `index`.
     #[inline]
-    pub unsafe fn take_unchecked(&mut self, index: usize) -> V {
-        match mem::replace(self.data.get_unchecked_mut(index), Entry::Empty(self.next_free)) {
+    pub unsafe fn take_unchecked(&mut self, index: Ix) -> V {
+        let take_index = index.into_usize();
+        match mem::replace(self.data.get_unchecked_mut(take_index), Entry::Empty(self.next_free)) {
             Entry::Empty(_) => ::unreachable::unreachable(),
             Entry::Full(value) => {
-                self.next_free = index;
+                self.next_free = take_index;
                 self.size -= 1;
                 value
             }
@@ -400,8 +424,8 @@ impl<V> Stash<V> {
 
     /// Get a reference to the value at `index`.
     #[inline]
-    pub fn get(&self, index: usize) -> Option<&V> {
-        match self.data.get(index) {
+    pub fn get(&self, index: Ix) -> Option<&V> {
+        match self.data.get(index.into_usize()) {
             Some(&Entry::Full(ref v)) => Some(v),
             _ => None,
         }
@@ -414,8 +438,8 @@ impl<V> Stash<V> {
     /// `indices` from `put` and is sure not to have taken the value
     /// associated with the given `index`.
     #[inline]
-    pub unsafe fn get_unchecked(&self, index: usize) -> &V {
-        match self.data.get_unchecked(index) {
+    pub unsafe fn get_unchecked(&self, index: Ix) -> &V {
+        match self.data.get_unchecked(index.into_usize()) {
             &Entry::Full(ref v) => v,
             _ => ::unreachable::unreachable()
         }
@@ -423,8 +447,8 @@ impl<V> Stash<V> {
 
     /// Get a mutable reference to the value at `index`.
     #[inline]
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut V> {
-        match self.data.get_mut(index) {
+    pub fn get_mut(&mut self, index: Ix) -> Option<&mut V> {
+        match self.data.get_mut(index.into_usize()) {
             Some(&mut Entry::Full(ref mut v)) => Some(v),
             _ => None,
         }
@@ -437,8 +461,8 @@ impl<V> Stash<V> {
     /// `indices` from `put` and is sure not to have taken the value
     /// associated with the given `index`.
     #[inline]
-    pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut V {
-        match self.data.get_unchecked_mut(index) {
+    pub unsafe fn get_unchecked_mut(&mut self, index: Ix) -> &mut V {
+        match self.data.get_unchecked_mut(index.into_usize()) {
             &mut Entry::Full(ref mut v) => v,
             _ => ::unreachable::unreachable()
         }
@@ -467,22 +491,23 @@ impl<V> Stash<V> {
     }
 }
 
-impl<V> IntoIterator for Stash<V> {
-    type Item = (usize, V);
-    type IntoIter = IntoIter<V>;
+impl<V, Ix: Index> IntoIterator for Stash<V, Ix> {
+    type Item = (Ix, V);
+    type IntoIter = IntoIter<V, Ix>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             len: self.len(),
             inner: self.data.into_iter().enumerate(),
+            _marker: marker::PhantomData,
         }
     }
 }
 
-impl<'a, V> IntoIterator for &'a Stash<V> {
-    type Item = (usize, &'a V);
-    type IntoIter = Iter<'a, V>;
+impl<'a, V, Ix: Index> IntoIterator for &'a Stash<V, Ix> {
+    type Item = (Ix, &'a V);
+    type IntoIter = Iter<'a, V, Ix>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -490,9 +515,9 @@ impl<'a, V> IntoIterator for &'a Stash<V> {
     }
 }
 
-impl<'a, V> IntoIterator for &'a mut Stash<V> {
-    type Item = (usize, &'a mut V);
-    type IntoIter = IterMut<'a, V>;
+impl<'a, V, Ix: Index> IntoIterator for &'a mut Stash<V, Ix> {
+    type Item = (Ix, &'a mut V);
+    type IntoIter = IterMut<'a, V, Ix>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -500,34 +525,34 @@ impl<'a, V> IntoIterator for &'a mut Stash<V> {
     }
 }
 
-
-impl<V> fmt::Debug for Stash<V>
-    where V: fmt::Debug
+impl<V, Ix> fmt::Debug for Stash<V, Ix>
+    where V: fmt::Debug,
+          Ix: fmt::Debug + Index
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map().entries(self).finish()
     }
 }
 
-impl<'a, V> Index<usize> for Stash<V> {
+impl<'a, V, Ix: Index> ops::Index<Ix> for Stash<V, Ix> {
     type Output = V;
     #[inline]
-    fn index(&self, index: usize) -> &V {
+    fn index(&self, index: Ix) -> &V {
         self.get(index).expect("index out of bounds")
     }
 }
 
-impl<'a, V> IndexMut<usize> for Stash<V> {
+impl<'a, V, Ix: Index> ops::IndexMut<Ix> for Stash<V, Ix> {
     #[inline]
-    fn index_mut(&mut self, index: usize) -> &mut V {
+    fn index_mut(&mut self, index: Ix) -> &mut V {
         self.get_mut(index).expect("index out of bounds")
     }
 }
 
 
-impl<V> Default for Stash<V> {
+impl<V, Ix: Index> Default for Stash<V, Ix> {
     #[inline]
     fn default() -> Self {
-        Stash::new()
+        Stash::with_capacity(0)
     }
 }

--- a/src/unique_stash/mod.rs
+++ b/src/unique_stash/mod.rs
@@ -151,13 +151,13 @@ pub struct IntoValues<V> {
     len: usize,
 }
 
-impl_iter!(Values, (<'a, V>), &'a V, entry::value_ref);
-impl_iter!(ValuesMut, (<'a, V>), &'a mut V, entry::value_mut);
-impl_iter!(IntoValues, (<V>), V, entry::value);
+impl_iter!(Values, (<'a, V>), &'a V, entry::value_ref, ());
+impl_iter!(ValuesMut, (<'a, V>), &'a mut V, entry::value_mut, ());
+impl_iter!(IntoValues, (<V>), V, entry::value, ());
 
-impl_iter!(Iter, (<'a, V>), (Tag, &'a V), entry::value_index_ref);
-impl_iter!(IterMut, (<'a, V>), (Tag, &'a mut V), entry::value_index_mut);
-impl_iter!(IntoIter, (<V>), (Tag, V), entry::value_index);
+impl_iter!(Iter, (<'a, V>), (Tag, &'a V), entry::value_index_ref, ());
+impl_iter!(IterMut, (<'a, V>), (Tag, &'a mut V), entry::value_index_mut, ());
+impl_iter!(IntoIter, (<V>), (Tag, V), entry::value_index, ());
 
 /// An `O(1)` amortized table that does not reuse keys.
 ///


### PR DESCRIPTION
Inspired by the petgraph library. The reason for a user to choose an index type smaller than usize is probably not to make Entry smaller, since most likely the V type is bigger anyway. The reason is for when storing lots of indices somewhere else, like when building graphs on top of stash. In that case the graph can end up storing lots of indices, so that size may actually matter.
So, one option could have been to keep the next_free field as an usize. I chose not to do that, thinking why not go all the way.
No testing done except from seeing that it compiles on rust 1.13.
