### PR TITLE
Added {get, get_mut, take}_unchecked methods and their benchmarks to Stash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ readme = "README.md"
 
 license = "MIT/Apache-2.0"
 description="An amortized `O(1)` table for cases where you don't need to choose the keys and want something faster than a HashTable."
+
+[dependencies]
+unreachable = "0.1.1"

--- a/benches/stash.rs
+++ b/benches/stash.rs
@@ -56,8 +56,46 @@ fn setup<'a>() -> (Stash<&'a str>, Vec<usize>) {
     (stash, tickets)
 }
 
+#[bench]
+fn get(b: &mut Bencher) {
+    let (stash, tickets) = setup();
     b.iter(|| {
-        test::black_box(&stash[*t]);
+        for &t in tickets.iter() {
+            test::black_box(stash.get(t).unwrap());
+        }
+    });
+}
+
+#[bench]
+fn get_unchecked(b: &mut Bencher) {
+    let (stash, tickets) = setup();
+    b.iter(|| {
+        for &t in tickets.iter() {
+            test::black_box(unsafe{ stash.get_unchecked(t) });
+        }
+    });
+}
+
+#[bench]
+fn get_mut(b: &mut Bencher) {
+    let (mut stash, tickets) = setup();
+    b.iter(|| {
+        for &t in tickets.iter() {
+            test::black_box(stash.get_mut(t).unwrap());
+        }
+    });
+}
+
+#[bench]
+fn get_unchecked_mut(b: &mut Bencher) {
+    let (mut stash, tickets) = setup();
+    b.iter(|| {
+        for &t in tickets.iter() {
+            test::black_box(unsafe{ stash.get_unchecked_mut(t) });
+        }
+    });
+}
+
     });
 }
 

--- a/benches/stash.rs
+++ b/benches/stash.rs
@@ -8,30 +8,43 @@ use test::Bencher;
 use stash::Stash;
 
 #[bench]
-fn bench(b: &mut Bencher) {
-    let mut stash = Stash::new();
+fn put_and_take(b: &mut Bencher) {
+    let mut stash = Stash::with_capacity(6);
     b.iter(|| {
         let t1 = stash.put("something");
         let t2 = stash.put("something");
-        let _ = stash.take(t1);
+        let _  = test::black_box(stash.take(t1).unwrap());
         let t3 = stash.put("something");
         let t4 = stash.put("something");
         let t5 = stash.put("something");
-        let _ = stash.take(t4);
+        let _  = test::black_box(stash.take(t4).unwrap());
         let t6 = stash.put("something");
-        let _ = stash.take(t3);
-        let _ = stash.take(t2);
-        let _ = stash.take(t5);
-        let _ = stash.take(t6);
+        let _  = test::black_box(stash.take(t3).unwrap());
+        let _  = test::black_box(stash.take(t2).unwrap());
+        let _  = test::black_box(stash.take(t5).unwrap());
+        let _  = test::black_box(stash.take(t6).unwrap());
     });
 }
 
 #[bench]
-fn lookup(b: &mut Bencher) {
-    let mut stash = Stash::new();
-    let mut tickets = Vec::new();
-    for _ in 0..100 {
-        tickets.push(stash.put("something"));
+fn put_and_take_unchecked(b: &mut Bencher) {
+    let mut stash = Stash::with_capacity(6);
+    b.iter(|| {
+        let t1 = stash.put("something");
+        let t2 = stash.put("something");
+        let _  = unsafe{ test::black_box(stash.take_unchecked(t1)) };
+        let t3 = stash.put("something");
+        let t4 = stash.put("something");
+        let t5 = stash.put("something");
+        let _  = unsafe{ test::black_box(stash.take_unchecked(t4)) };
+        let t6 = stash.put("something");
+        let _  = unsafe{ test::black_box(stash.take_unchecked(t3)) };
+        let _  = unsafe{ test::black_box(stash.take_unchecked(t2)) };
+        let _  = unsafe{ test::black_box(stash.take_unchecked(t5)) };
+        let _  = unsafe{ test::black_box(stash.take_unchecked(t6)) };
+    });
+}
+
 
 fn setup<'a>() -> (Stash<&'a str>, Vec<usize>) {
     let n = 100;

--- a/benches/stash.rs
+++ b/benches/stash.rs
@@ -50,11 +50,7 @@ fn setup<'a>() -> (Stash<&'a str>, Vec<usize>) {
 
 #[bench]
 fn iter_sparse(b: &mut Bencher) {
-    let mut stash = Stash::new();
-    let mut tickets = Vec::new();
-    for _ in 0..100 {
-        tickets.push(stash.put("something"));
-    }
+    let (mut stash, tickets) = setup();
     stash.put("something");
     for t in tickets {
         stash.take(t);
@@ -66,10 +62,7 @@ fn iter_sparse(b: &mut Bencher) {
 
 #[bench]
 fn iter(b: &mut Bencher) {
-    let mut stash = Stash::new();
-    for _ in 0..100 {
-        stash.put("something");
-    }
+    let (stash, _) = setup();
     b.iter(|| {
         for i in test::black_box(&stash) {
             test::black_box(i);
@@ -79,11 +72,7 @@ fn iter(b: &mut Bencher) {
 
 #[bench]
 fn insert_delete(b: &mut Bencher) {
-    let mut stash = Stash::new();
-
-    for _ in 0..100 {
-        stash.put("something");
-    }
+    let (mut stash, _) = setup();
 
     stash.take(10);
     stash.take(50);

--- a/benches/stash.rs
+++ b/benches/stash.rs
@@ -45,6 +45,99 @@ fn put_and_take_unchecked(b: &mut Bencher) {
     });
 }
 
+#[bench]
+fn put_and_take_block(b: &mut Bencher) {
+    let mut stash = Stash::with_capacity(10);
+    b.iter(|| {
+        let t0 = stash.put("something");
+        let t1 = stash.put("something");
+        let t2 = stash.put("something");
+        let t3 = stash.put("something");
+        let t4 = stash.put("something");
+        let t5 = stash.put("something");
+        let t6 = stash.put("something");
+        let t7 = stash.put("something");
+        let t8 = stash.put("something");
+        let t9 = stash.put("something");
+        let _ = test::black_box(stash.take(t1).unwrap());
+        let _ = test::black_box(stash.take(t4).unwrap());
+        let _ = test::black_box(stash.take(t3).unwrap());
+        let _ = test::black_box(stash.take(t2).unwrap());
+        let _ = test::black_box(stash.take(t5).unwrap());
+        let _ = test::black_box(stash.take(t6).unwrap());
+        let _ = test::black_box(stash.take(t0).unwrap());
+        let _ = test::black_box(stash.take(t8).unwrap());
+        let _ = test::black_box(stash.take(t9).unwrap());
+        let _ = test::black_box(stash.take(t7).unwrap());
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = test::black_box(stash.take(t4).unwrap());
+        let _ = test::black_box(stash.take(t5).unwrap());
+        let _ = test::black_box(stash.take(t3).unwrap());
+        let _ = test::black_box(stash.take(t1).unwrap());
+        let _ = test::black_box(stash.take(t9).unwrap());
+        let _ = test::black_box(stash.take(t2).unwrap());
+        let _ = test::black_box(stash.take(t6).unwrap());
+        let _ = test::black_box(stash.take(t7).unwrap());
+        let _ = test::black_box(stash.take(t8).unwrap());
+        let _ = test::black_box(stash.take(t0).unwrap());
+    });
+}
+
+#[bench]
+fn put_and_take_unchecked_block(b: &mut Bencher) {
+    let mut stash = Stash::with_capacity(10);
+    b.iter(|| {
+        let t0 = stash.put("something");
+        let t1 = stash.put("something");
+        let t2 = stash.put("something");
+        let t3 = stash.put("something");
+        let t4 = stash.put("something");
+        let t5 = stash.put("something");
+        let t6 = stash.put("something");
+        let t7 = stash.put("something");
+        let t8 = stash.put("something");
+        let t9 = stash.put("something");
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t1)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t4)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t3)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t2)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t5)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t6)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t0)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t8)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t9)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t7)) };
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = stash.put("something");
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t4)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t5)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t3)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t1)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t9)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t2)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t6)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t7)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t8)) };
+        let _ = unsafe{ test::black_box(stash.take_unchecked(t0)) };
+    });
+}
 
 fn setup<'a>() -> (Stash<&'a str>, Vec<usize>) {
     let n = 100;

--- a/benches/stash.rs
+++ b/benches/stash.rs
@@ -96,6 +96,13 @@ fn get_unchecked_mut(b: &mut Bencher) {
     });
 }
 
+#[bench]
+fn ops_index(b: &mut Bencher) {
+    let (stash, tickets) = setup();
+    b.iter(|| {
+        for &i in tickets.iter() {
+            test::black_box(stash[i]);
+        }
     });
 }
 

--- a/benches/stash.rs
+++ b/benches/stash.rs
@@ -32,8 +32,17 @@ fn lookup(b: &mut Bencher) {
     let mut tickets = Vec::new();
     for _ in 0..100 {
         tickets.push(stash.put("something"));
+
+fn setup<'a>() -> (Stash<&'a str>, Vec<usize>) {
+    let n = 100;
+    let mut stash = Stash::with_capacity(n);
+    let mut tickets = Vec::with_capacity(n);
+    for _ in 0..n {
+        tickets.push(stash.put("foo"));
     }
-    let t = &tickets[20];
+    (stash, tickets)
+}
+
     b.iter(|| {
         test::black_box(&stash[*t]);
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //!
 //! <sup>†</sup>Blazing means an order of magnitude faster than hash maps and btree maps.
 
+extern crate unreachable;
+
 #[macro_use]
 mod iter_macro;
 

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -364,20 +364,22 @@ impl<V> Stash<V> {
 
     /// Take an item from a slot (if non empty).
     pub fn take(&mut self, index: usize) -> Option<V> {
-        if let Some(entry) = self.data.get_mut(index) {
-            match mem::replace(entry, Entry::Empty(self.next_free)) {
+        match self.data.get_mut(index) {
+            None => None,
+            Some(entry) => match mem::replace(entry, Entry::Empty(self.next_free)) {
                 Entry::Empty(free_slot) => {
-                    // Just put it back.
                     *entry = Entry::Empty(free_slot);
-                }
+                    None
+                },
                 Entry::Full(value) => {
                     self.next_free = index;
                     self.size -= 1;
-                    return Some(value);
+                    Some(value)
                 }
             }
         }
-        None
+    }
+
     /// Take an item from a slot (if non empty) without bounds or empty checking.
     /// So use it very carefully!
     /// 

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -280,7 +280,7 @@ impl<V> Stash<V> {
             unsafe {
                 match mem::replace(self.data.get_unchecked_mut(loc), Entry::Full(value)) {
                     Entry::Empty(next_free) => next_free,
-                    _ => unreachable!(),
+                    _ => ::unreachable::unreachable(),
                 }
             }
         };

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -378,6 +378,22 @@ impl<V> Stash<V> {
             }
         }
         None
+    /// Take an item from a slot (if non empty) without bounds or empty checking.
+    /// So use it very carefully!
+    /// 
+    /// This can be safely used as long as the user does not mutate
+    /// `indices` from `put` and is sure not to have taken the value
+    /// associated with the given `index`.
+    #[inline]
+    pub unsafe fn take_unchecked(&mut self, index: usize) -> V {
+        match mem::replace(self.data.get_unchecked_mut(index), Entry::Empty(self.next_free)) {
+            Entry::Empty(_) => ::unreachable::unreachable(),
+            Entry::Full(value) => {
+                self.next_free = index;
+                self.size -= 1;
+                value
+            }
+        }
     }
 
     /// Get a reference to the value at `index`.
@@ -389,12 +405,40 @@ impl<V> Stash<V> {
         }
     }
 
+    /// Get a reference to the value at `index` without bounds or empty checking.
+    /// So use it very carefully!
+    /// 
+    /// This can be safely used as long as the user does not mutate
+    /// `indices` from `put` and is sure not to have taken the value
+    /// associated with the given `index`.
+    #[inline]
+    pub unsafe fn get_unchecked(&self, index: usize) -> &V {
+        match self.data.get_unchecked(index) {
+            &Entry::Full(ref v) => v,
+            _ => ::unreachable::unreachable()
+        }
+    }
+
     /// Get a mutable reference to the value at `index`.
     #[inline]
     pub fn get_mut(&mut self, index: usize) -> Option<&mut V> {
         match self.data.get_mut(index) {
             Some(&mut Entry::Full(ref mut v)) => Some(v),
             _ => None,
+        }
+    }
+
+    /// Get a mutable reference to the value at `index` without bounds or empty checking.
+    /// So use it very carefully!
+    /// 
+    /// This can be safely used as long as the user does not mutate
+    /// `indices` from `put` and is sure not to have taken the value
+    /// associated with the given `index`.
+    #[inline]
+    pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut V {
+        match self.data.get_unchecked_mut(index) {
+            &mut Entry::Full(ref mut v) => v,
+            _ => ::unreachable::unreachable()
         }
     }
 


### PR DESCRIPTION
I have added the methods  `get_unchecked`, `get_unchecked_mut` and `take_unchecked` to `Stash` and also added associated benchmark tests for them. The speedup for `get_unchecked`, `get_unchecked_mut` is quite decent (about 50%) while for `take_unchecked` it isn't so huge (just about 10%). Also a `setup` routine for the `Stash` benchmarks was added.

The use-case for the user knowing when he or she can "safely" use the unchecked versions is similar to `Vec`s `get_unchecked` methods and should be provided by this crate since it is an important API for performance depending projects that could benefit from this data structure such as SAT solvers.