### PR TITLE
Add next_index method.

### DIFF
--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -283,6 +283,15 @@ impl<V, Ix> Stash<V, Ix>
         }
     }
 
+    /// Get the index that would be returned from next call to `put`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the size of the `Stash<V, Ix>` would overflow the `Ix` index type.
+    pub fn next_index(&self) -> Ix {
+        Ix::from_usize(self.next_free)
+    }
+
     /// Put a value into the stash.
     ///
     /// Returns the index at which this value was stored.


### PR DESCRIPTION
Useful for situations where the stored value itself contains its index
in the stash.

I looked at the vacant_entry API in the slab crate, but decided that this simpler way of doing it is probably good enough.