### PR TITLE
Make crate no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ license = "MIT/Apache-2.0"
 description="An amortized `O(1)` table for cases where you don't need to choose the keys and want something faster than a HashTable."
 
 [features]
+default = ["std"]
+std = ["serde/std"]
 serialization = ["serde", "serde_derive"]
 
 [dependencies]
 unreachable = "1"
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, default-features = false }
 serde_derive = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/benches/unique_stash.rs
+++ b/benches/unique_stash.rs
@@ -3,7 +3,6 @@
 extern crate stash;
 extern crate test;
 
-use std::iter;
 use test::Bencher;
 
 use stash::{Tag, UniqueStash};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@
 //! context tables.
 //!
 //! <sup>†</sup>Blazing means an order of magnitude faster than hash maps and btree maps.
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
+extern crate alloc;
 extern crate unreachable;
 
 #[cfg(test)]

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -1,10 +1,10 @@
-use std::fmt;
-use std::iter;
-use std::marker;
-use std::mem;
-use std::ops;
-use std::slice;
-use std::vec;
+use alloc::vec::{self, Vec};
+use core::fmt;
+use core::iter;
+use core::marker;
+use core::mem;
+use core::ops;
+use core::slice;
 
 mod entry;
 use self::entry::Entry;

--- a/src/unique_stash/entry.rs
+++ b/src/unique_stash/entry.rs
@@ -1,6 +1,6 @@
 use self::Entry::*;
 use super::Tag;
-use std::mem;
+use core::mem;
 
 #[derive(Clone)]
 pub enum Entry<V> {

--- a/src/unique_stash/mod.rs
+++ b/src/unique_stash/mod.rs
@@ -1,11 +1,11 @@
-use std::error::Error;
-use std::fmt;
-use std::iter;
-use std::mem;
-use std::ops::{Index, IndexMut};
-use std::slice;
-use std::str::FromStr;
-use std::vec;
+use alloc::vec::{self, Vec};
+use core::error::Error;
+use core::fmt;
+use core::iter;
+use core::mem;
+use core::ops::{Index, IndexMut};
+use core::slice;
+use core::str::FromStr;
 
 use self::entry::{Entry, VerEntry};
 
@@ -553,9 +553,9 @@ impl<V> Default for UniqueStash<V> {
 #[cfg(feature = "serialization")]
 mod serialization {
     use super::*;
+    use core::marker;
     use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
     use serde::ser::{Serialize, SerializeSeq, Serializer};
-    use std::marker;
 
     impl<V> Serialize for UniqueStash<V>
     where


### PR DESCRIPTION
This allows the crate to be used in `#![no_std]` environments; not much else to be said I suppose.

Since there's no GA/CI, I ran the following and all succeeded:

```shell
cargo fmt --all
cargo test
cargo test --no-default-features
cargo test --all-features
cargo test --no-default-features --features serialization
cargo bench
cargo bench --no-default-features
cargo clippy -- -D clippy::all
cargo clippy --no-default-features -- -D clippy::all
cargo clippy --no-default-features --features serialization -- -D clippy::all
```

Let me know if there's anything else I should check!